### PR TITLE
feat: upgrade get-tsconfig to v5 beta

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    name: Test
+    name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -49,3 +49,28 @@ jobs:
 
       - name: Lint
         run: pnpm lint
+
+  runtime:
+    name: Runtime (Node 20.20.0)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Use Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 20.20.0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build and run CLI
+        run: |
+          pnpm build
+          node ./dist/cli/index.mjs --help

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Get pnpm store directory
         shell: bash
-        run: echo "PNPM_STORE=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "PNPM_STORE=$(pnpm store path --silent)" >> "$GITHUB_ENV"
 
       - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         name: Cache pnpm
@@ -50,27 +50,8 @@ jobs:
       - name: Lint
         run: pnpm lint
 
-  runtime:
-    name: Runtime (Node 20.20.0)
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Use Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version: 20.20.0
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build and run CLI
+      - name: Test Node.js 20.20.0 runtime
+        if: matrix.os == 'ubuntu-latest'
         run: |
-          pnpm build
-          node ./dist/cli/index.mjs --help
+          pnpm --use-node-version=20.20.0 build
+          pnpm --use-node-version=20.20.0 exec node ./dist/cli/index.mjs --help

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,8 +50,6 @@ jobs:
       - name: Lint
         run: pnpm lint
 
-      - name: Test Node.js 20.20.0 runtime
+      - name: Test Node.js 20.20.0
         if: matrix.os == 'ubuntu-latest'
-        run: |
-          pnpm --use-node-version=20.20.0 build
-          pnpm --use-node-version=20.20.0 exec node ./dist/cli/index.mjs --help
+        run: pnpm --use-node-version=20.20.0 tsx tests

--- a/package.json
+++ b/package.json
@@ -59,6 +59,9 @@
 		"test": "node tests/index.ts",
 		"prepack": "pnpm build && clean-pkg-json"
 	},
+	"engines": {
+		"node": ">=20.20.0"
+	},
 	"dependencies": {
 		"@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
 		"@eslint/js": "^9.39.2",
@@ -83,7 +86,7 @@
 		"eslint-plugin-vue": "^10.9.2",
 		"eslint-plugin-yml": "^3.6.0",
 		"get-conditions": "^1.0.1",
-		"get-tsconfig": "^4.14.0",
+		"get-tsconfig": "5.0.0-beta.5",
 		"globals": "^17.7.0",
 		"nano-spawn": "^2.1.0",
 		"resolve-pkg-maps": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,8 +78,8 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
       get-tsconfig:
-        specifier: ^4.14.0
-        version: 4.14.0
+        specifier: 5.0.0-beta.5
+        version: 5.0.0-beta.5
       globals:
         specifier: ^17.7.0
         version: 17.7.0
@@ -1824,6 +1824,10 @@ packages:
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  get-tsconfig@5.0.0-beta.5:
+    resolution: {integrity: sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==}
+    engines: {node: '>=20.20.0'}
 
   git-hooks-list@4.2.1:
     resolution: {integrity: sha512-WNvqJjOxxs/8ZP9+DWdwWJ7cDsd60NHf39XnD82pDVrKO5q7xfPqpkK6hwEAmBa/ZSEE4IOoR75EzbbIuwGlMw==}
@@ -4619,6 +4623,10 @@ snapshots:
       get-intrinsic: 1.3.0
 
   get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  get-tsconfig@5.0.0-beta.5:
     dependencies:
       resolve-pkg-maps: 1.0.0
 

--- a/src/configs/react.ts
+++ b/src/configs/react.ts
@@ -1,9 +1,9 @@
-import type { TsConfigResult } from 'get-tsconfig';
+import type { TsconfigResult } from 'get-tsconfig';
 import reactPlugin from 'eslint-plugin-react';
 import reactHooksPlugin from 'eslint-plugin-react-hooks';
 import { defineConfig } from '../utils/define-config.ts';
 
-export const react = (_tsconfig: TsConfigResult | null) => defineConfig({
+export const react = (_tsconfig: TsconfigResult | undefined) => defineConfig({
 	files: ['**/*.{jsx,tsx}'],
 
 	plugins: {

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -3,7 +3,7 @@
  * - https://github.com/import-js/eslint-plugin-import/blob/master/config/typescript.js
  * - https://github.com/xojs/eslint-config-xo-typescript/blob/master/index.js
  */
-import type { TsConfigResult } from 'get-tsconfig';
+import type { TsconfigResult } from 'get-tsconfig';
 import tsPlugin from '@typescript-eslint/eslint-plugin';
 import tsParser from '@typescript-eslint/parser';
 import importPlugin from 'eslint-plugin-import-x';
@@ -23,7 +23,7 @@ export const parseTypescript = defineConfig({
 	settings: importPlugin.configs.typescript.settings,
 });
 
-export const typescript = (tsconfig: TsConfigResult | null) => {
+export const typescript = (tsconfig: TsconfigResult | undefined) => {
 	// Check if allowImportingTsExtensions is enabled
 	const hasAllowImportingTsExtensions = (
 		tsconfig?.config?.compilerOptions?.allowImportingTsExtensions === true

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export const pvtnbr = (
 	options?: Options,
 ): Linter.Config[] => {
 	const cwd = options?.cwd ?? process.cwd();
-	const tsconfig = getTsconfig(cwd);
+	const tsconfig = getTsconfig(cwd, { typescriptVersion: false });
 
 	return [
 		defineConfig({


### PR DESCRIPTION
## Problem

get-tsconfig v5 requires Node 20.20.0 and can apply TypeScript-version defaults based on a consumer's local installation. lintroll only needs the explicitly configured `allowImportingTsExtensions` option, so automatic defaults would make its lint behavior depend on the consumer environment.

## Changes

- Upgrade to `get-tsconfig@5.0.0-beta.5` and migrate its result type.
- Parse literal tsconfig values to preserve lintroll's existing configuration semantics.
- Declare Node >=20.20.0 for the published package.
- Add a Node 20.20.0 CI runtime smoke test for the compiled CLI while retaining Node 24 full tests for TypeScript source execution.
