### PR TITLE
test: add lint performance benchmarks

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,7 @@
+# Benchmarks
+
+Run the one-shot CLI benchmark with `pnpm bench`.
+
+Run ESLint's per-rule timing report with `pnpm bench:rules`.
+
+Benchmark results depend on the machine and current git-tracked files. Compare runs on the same machine with no competing workloads.

--- a/bench/lint.ts
+++ b/bench/lint.ts
@@ -1,0 +1,17 @@
+import { bench, run } from 'mitata';
+import spawn from 'nano-spawn';
+
+bench('lintroll --git', async () => {
+	await spawn(process.execPath, [
+		'-C',
+		'development',
+		'./src/cli/index.ts',
+		'--git',
+	], {
+		stdio: 'ignore',
+	});
+})
+	// Each sample starts a full CLI process. Concurrent samples would contend for CPU and disk.
+	.gc(false);
+
+await run({ throw: true });

--- a/bench/rules.ts
+++ b/bench/rules.ts
@@ -1,0 +1,11 @@
+import spawn from 'nano-spawn';
+
+await spawn(process.execPath, [
+	'-C',
+	'development',
+	'./src/cli/index.ts',
+	'--git',
+], {
+	env: { TIMING: 'all' },
+	stdio: 'inherit',
+});

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
 	},
 	"packageManager": "pnpm@10.27.0",
 	"scripts": {
+		"bench": "node --expose-gc bench/lint.ts",
+		"bench:rules": "node bench/rules.ts",
 		"build": "pkgroll --export-condition=node --export-condition=development --minify --clean-dist",
 		"type-check": "tsc",
 		"lint": "node -C development ./src/cli/index.ts --git",
@@ -107,6 +109,7 @@
 		"find-up-simple": "^1.0.1",
 		"fs-fixture": "^2.14.0",
 		"manten": "2.0.1",
+		"mitata": "^1.0.34",
 		"pkgroll": "^2.27.1",
 		"react": "^19.2.7",
 		"read-package-up": "^12.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       manten:
         specifier: 2.0.1
         version: 2.0.1
+      mitata:
+        specifier: ^1.0.34
+        version: 1.0.34
       pkgroll:
         specifier: ^2.27.1
         version: 2.27.1(typescript@6.0.3)
@@ -2346,6 +2349,9 @@ packages:
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
+  mitata@1.0.34:
+    resolution: {integrity: sha512-Mc3zrtNBKIMeHSCQ0XqRLo1vbdIx1wvFV9c8NJAiyho6AjNfMY8bVhbS12bwciUdd1t4rj8099CH3N3NFahaUA==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -5327,6 +5333,8 @@ snapshots:
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
+
+  mitata@1.0.34: {}
 
   ms@2.1.3: {}
 


### PR DESCRIPTION
## Problem

Lintroll has no reproducible way to measure one-shot CLI latency or identify expensive ESLint rules. That makes rule-policy performance tradeoffs difficult to evaluate.

## Changes

- Add a mitata benchmark for the real `lintroll --git` subprocess path.
- Add a portable per-rule timing script using ESLint's `TIMING=all` support.
- Document benchmark commands and the requirement to compare runs on the same idle machine.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. `develop`
2. **#128** 👈 current
3. #129
<!-- stack:links:end -->