### PR TITLE
feat: add fast lint mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ lintroll --fix
 lintroll --cache
 ```
 
+#### Lint faster with direct cycle detection
+
+Fast mode limits import cycle detection to direct two-module cycles. Full mode remains the default and detects cycles at any depth.
+
+```sh
+lintroll --fast
+```
+
+Set `LINTROLL_MODE=fast` to enable the same mode through the CLI environment.
+
+When using an `eslint.config.*` file, configure `pvtnbr({ mode: 'fast' })` in that file instead of passing `--fast`.
+
 #### Lint only staged files
 ```sh
 lintroll --staged
@@ -102,6 +114,7 @@ Usage:
 Flags:
       --cache                          Only check changed files
       --cache-location <string>        Path to the cache file or directory
+      --fast                           Limit import cycle traversal for faster linting
       --fix                            Automatically fix problems
       --git                            Only lint git tracked files within the files passed in
   -h, --help                           Show help
@@ -233,7 +246,7 @@ Each plugin in this ESLint configuration targets specific aspects of your code, 
 
 ## API
 
-### pvtbr(options)
+### pvtnbr(options)
 
 The main config factory. It takes an object of options and returns a config object.
 
@@ -244,6 +257,14 @@ Type: `boolean | string[]`
 Default: `false`
 
 Whether to lint Node.js code. When `true`, it will treat all files as Node.js files. You can also pass in an array of glob patterns to specify which files are Node.js files.
+
+#### options.mode
+
+Type: `'full' | 'fast'`
+
+Default: `'full'`
+
+Fast mode limits import cycle detection to direct two-module cycles. Full mode detects cycles at any depth.
 
 ### defineConfig(configs)
 

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ Fast mode limits import cycle detection to direct two-module cycles. Full mode r
 lintroll --fast
 ```
 
-Set `LINTROLL_MODE=fast` to enable the same mode through the CLI environment.
+Set `LINTROLL_MODE=fast` to enable the same behavior through the CLI environment.
 
-When using an `eslint.config.*` file, configure `pvtnbr({ mode: 'fast' })` in that file instead of passing `--fast`.
+When using an `eslint.config.*` file, configure `pvtnbr({ fast: true })` in that file instead of passing `--fast`.
 
 #### Lint only staged files
 ```sh
@@ -258,11 +258,11 @@ Default: `false`
 
 Whether to lint Node.js code. When `true`, it will treat all files as Node.js files. You can also pass in an array of glob patterns to specify which files are Node.js files.
 
-#### options.mode
+#### options.fast
 
-Type: `'full' | 'fast'`
+Type: `boolean`
 
-Default: `'full'`
+Default: `false`
 
 Fast mode limits import cycle detection to direct two-module cycles. Full mode detects cycles at any depth.
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -2,6 +2,10 @@
 
 Run the one-shot CLI benchmark with `pnpm bench`.
 
+Run the generated config benchmark with `pnpm bench:config`. Set `LINTROLL_MODE=fast` to measure fast mode.
+
 Run ESLint's per-rule timing report with `pnpm bench:rules`.
+
+Run generated-config rule timing with `pnpm bench:config:rules`. Set `LINTROLL_MODE=fast` to compare fast mode.
 
 Benchmark results depend on the machine and current git-tracked files. Compare runs on the same machine with no competing workloads.

--- a/bench/README.md
+++ b/bench/README.md
@@ -2,10 +2,18 @@
 
 Run the one-shot CLI benchmark with `pnpm bench`.
 
-Run the generated config benchmark with `pnpm bench:config`. Set `LINTROLL_MODE=fast` to measure fast mode.
+Run the generated config benchmark with `pnpm bench:config`. Pass `--fast` to measure fast mode:
+
+```sh
+pnpm bench:config --fast
+```
 
 Run ESLint's per-rule timing report with `pnpm bench:rules`.
 
-Run generated-config rule timing with `pnpm bench:config:rules`. Set `LINTROLL_MODE=fast` to compare fast mode.
+Run generated-config rule timing with `pnpm bench:config:rules`. Pass `--fast` to compare fast mode:
+
+```sh
+pnpm bench:config:rules --fast
+```
 
 Benchmark results depend on the machine and current git-tracked files. Compare runs on the same machine with no competing workloads.

--- a/bench/config-rules.ts
+++ b/bench/config-rules.ts
@@ -24,4 +24,4 @@ const output = [...ruleTimes]
 		time,
 	}));
 
-process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+console.log(JSON.stringify(output, null, 2));

--- a/bench/config-rules.ts
+++ b/bench/config-rules.ts
@@ -1,7 +1,7 @@
 import { ESLint } from 'eslint';
 import { pvtnbr } from '#pvtnbr';
 
-const mode = process.env.LINTROLL_MODE === 'fast' ? 'fast' : 'full';
+const mode = process.argv.includes('--fast') ? 'fast' : 'full';
 const eslint = new ESLint({
 	baseConfig: pvtnbr({ mode }),
 	overrideConfigFile: true,

--- a/bench/config-rules.ts
+++ b/bench/config-rules.ts
@@ -1,9 +1,9 @@
 import { ESLint } from 'eslint';
 import { pvtnbr } from '#pvtnbr';
 
-const mode = process.argv.includes('--fast') ? 'fast' : 'full';
+const fast = process.argv.includes('--fast');
 const eslint = new ESLint({
-	baseConfig: pvtnbr({ mode }),
+	baseConfig: pvtnbr({ fast }),
 	overrideConfigFile: true,
 	stats: true,
 });

--- a/bench/config-rules.ts
+++ b/bench/config-rules.ts
@@ -1,0 +1,27 @@
+import { ESLint } from 'eslint';
+import { pvtnbr } from '#pvtnbr';
+
+const mode = process.env.LINTROLL_MODE === 'fast' ? 'fast' : 'full';
+const eslint = new ESLint({
+	baseConfig: pvtnbr({ mode }),
+	overrideConfigFile: true,
+	stats: true,
+});
+const ruleTimes = new Map<string, number>();
+
+for (const result of await eslint.lintFiles(['.'])) {
+	for (const pass of result.stats?.times.passes ?? []) {
+		for (const [name, time] of Object.entries(pass.rules ?? {})) {
+			ruleTimes.set(name, (ruleTimes.get(name) ?? 0) + time.total);
+		}
+	}
+}
+
+const output = [...ruleTimes]
+	.sort(([, left], [, right]) => right - left)
+	.map(([name, time]) => ({
+		name,
+		time,
+	}));
+
+process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);

--- a/bench/config.ts
+++ b/bench/config.ts
@@ -2,11 +2,11 @@ import { bench, run } from 'mitata';
 import { ESLint } from 'eslint';
 import { pvtnbr } from '#pvtnbr';
 
-const mode = process.argv.includes('--fast') ? 'fast' : 'full';
+const fast = process.argv.includes('--fast');
 
-bench(`generated config (${mode})`, async () => {
+bench(`generated config (${fast ? 'fast' : 'full'})`, async () => {
 	const eslint = new ESLint({
-		baseConfig: pvtnbr({ mode }),
+		baseConfig: pvtnbr({ fast }),
 		overrideConfigFile: true,
 	});
 

--- a/bench/config.ts
+++ b/bench/config.ts
@@ -2,7 +2,7 @@ import { bench, run } from 'mitata';
 import { ESLint } from 'eslint';
 import { pvtnbr } from '#pvtnbr';
 
-const mode = process.env.LINTROLL_MODE === 'fast' ? 'fast' : 'full';
+const mode = process.argv.includes('--fast') ? 'fast' : 'full';
 
 bench(`generated config (${mode})`, async () => {
 	const eslint = new ESLint({

--- a/bench/config.ts
+++ b/bench/config.ts
@@ -1,0 +1,17 @@
+import { bench, run } from 'mitata';
+import { ESLint } from 'eslint';
+import { pvtnbr } from '#pvtnbr';
+
+const mode = process.env.LINTROLL_MODE === 'fast' ? 'fast' : 'full';
+
+bench(`generated config (${mode})`, async () => {
+	const eslint = new ESLint({
+		baseConfig: pvtnbr({ mode }),
+		overrideConfigFile: true,
+	});
+
+	await eslint.lintFiles(['.']);
+})
+	.gc(false);
+
+await run({ throw: true });

--- a/bench/lint.ts
+++ b/bench/lint.ts
@@ -10,8 +10,6 @@ bench('lintroll --git', async () => {
 	], {
 		stdio: 'ignore',
 	});
-})
-	// Each sample starts a full CLI process. Concurrent samples would contend for CPU and disk.
-	.gc(false);
+});
 
 await run({ throw: true });

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
 	"packageManager": "pnpm@10.27.0",
 	"scripts": {
 		"bench": "node --expose-gc bench/lint.ts",
+		"bench:config": "node --expose-gc -C development bench/config.ts",
+		"bench:config:rules": "node -C development bench/config-rules.ts",
 		"bench:rules": "node bench/rules.ts",
 		"build": "pkgroll --export-condition=node --export-condition=development --minify --clean-dist",
 		"type-check": "tsc",

--- a/src/cli/get-config.ts
+++ b/src/cli/get-config.ts
@@ -32,8 +32,8 @@ export const getConfig = async (
 	);
 
 	if (configFilePath) {
-		if (options.mode === 'fast') {
-			throw new Error(`Fast mode is unavailable with ${configFilePath}. Use pvtnbr({ mode: 'fast' }) in the config file instead.`);
+		if (options.fast) {
+			throw new Error(`Fast mode is unavailable with ${configFilePath}. Use pvtnbr({ fast: true }) in the config file instead.`);
 		}
 
 		let configModule: ConfigModule = await tsImport(

--- a/src/cli/get-config.ts
+++ b/src/cli/get-config.ts
@@ -32,6 +32,10 @@ export const getConfig = async (
 	);
 
 	if (configFilePath) {
+		if (options.mode === 'fast') {
+			throw new Error(`Fast mode is unavailable with ${configFilePath}. Use pvtnbr({ mode: 'fast' }) in the config file instead.`);
+		}
+
 		let configModule: ConfigModule = await tsImport(
 			pathToFileURL(configFilePath).toString(),
 			import.meta.url,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -54,6 +54,10 @@ const argv = cli({
 			type: [String],
 			description: 'Allow abbreviations',
 		},
+		fast: {
+			type: Boolean,
+			description: 'Skip expensive lint checks',
+		},
 	},
 });
 
@@ -67,6 +71,12 @@ const isNodeEnabled = (
 	const globs = flag.filter(glob => glob.length > 0);
 	return (globs.length > 0) ? globs : true;
 };
+
+const mode = (
+	argv.flags.fast || process.env.LINTROLL_MODE === 'fast'
+)
+	? 'fast'
+	: 'full';
 
 // Normalize paths to forward slashes for consistent cross-platform comparison
 const normalizePath = (filePath: string) => filePath.replaceAll('\\', '/');
@@ -99,6 +109,7 @@ const normalizePath = (filePath: string) => filePath.replaceAll('\\', '/');
 		cwd,
 		baseConfig: await getConfig({
 			cwd,
+			mode,
 			node: isNodeEnabled(argv.flags.node),
 			allowAbbreviations: {
 				exactWords: argv.flags.allowAbbreviation,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -72,11 +72,9 @@ const isNodeEnabled = (
 	return (globs.length > 0) ? globs : true;
 };
 
-const mode = (
+const fast = (
 	argv.flags.fast || process.env.LINTROLL_MODE === 'fast'
-)
-	? 'fast'
-	: 'full';
+);
 
 // Normalize paths to forward slashes for consistent cross-platform comparison
 const normalizePath = (filePath: string) => filePath.replaceAll('\\', '/');
@@ -109,7 +107,7 @@ const normalizePath = (filePath: string) => filePath.replaceAll('\\', '/');
 		cwd,
 		baseConfig: await getConfig({
 			cwd,
-			mode,
+			fast,
 			node: isNodeEnabled(argv.flags.node),
 			allowAbbreviations: {
 				exactWords: argv.flags.allowAbbreviation,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -56,7 +56,7 @@ const argv = cli({
 		},
 		fast: {
 			type: Boolean,
-			description: 'Skip expensive lint checks',
+			description: 'Limit import cycle traversal for faster linting',
 		},
 	},
 });

--- a/src/configs/imports.ts
+++ b/src/configs/imports.ts
@@ -1,12 +1,15 @@
 import { fileURLToPath } from 'node:url';
 import importPlugin from 'eslint-plugin-import-x';
+import type { Options } from '../types.ts';
 import { defineConfig } from '../utils/define-config.ts';
 
 const pkgMapsResolver = fileURLToPath(
 	import.meta.resolve('#pkg-maps-resolver'),
 );
 
-export const importsConfig = defineConfig({
+export const importsConfig = (
+	mode: Options['mode'],
+) => defineConfig({
 	plugins: {
 		'import-x': importPlugin,
 	},
@@ -96,7 +99,7 @@ export const importsConfig = defineConfig({
 		// https://github.com/import-js/eslint-plugin-import/blob/e6f6018/docs/rules/no-cycle.md
 		'import-x/no-cycle': ['error', {
 			ignoreExternal: true,
-			maxDepth: '∞',
+			maxDepth: mode === 'fast' ? 1 : '∞',
 		}],
 
 		// https://github.com/import-js/eslint-plugin-import/blob/e6f6018/docs/rules/no-duplicates.md
@@ -165,8 +168,10 @@ export const importsConfig = defineConfig({
 	},
 });
 
-export const imports = [
-	importsConfig,
+export const imports = (
+	mode: Options['mode'],
+) => [
+	importsConfig(mode),
 
 	// Bundled files
 	defineConfig({

--- a/src/configs/imports.ts
+++ b/src/configs/imports.ts
@@ -8,7 +8,7 @@ const pkgMapsResolver = fileURLToPath(
 );
 
 export const importsConfig = (
-	mode: Options['mode'],
+	fast: Options['fast'],
 ) => defineConfig({
 	plugins: {
 		'import-x': importPlugin,
@@ -99,7 +99,7 @@ export const importsConfig = (
 		// https://github.com/import-js/eslint-plugin-import/blob/e6f6018/docs/rules/no-cycle.md
 		'import-x/no-cycle': ['error', {
 			ignoreExternal: true,
-			maxDepth: mode === 'fast' ? 1 : '∞',
+			maxDepth: fast ? 1 : '∞',
 		}],
 
 		// https://github.com/import-js/eslint-plugin-import/blob/e6f6018/docs/rules/no-duplicates.md
@@ -169,9 +169,9 @@ export const importsConfig = (
 });
 
 export const imports = (
-	mode: Options['mode'],
+	fast: Options['fast'],
 ) => [
-	importsConfig(mode),
+	importsConfig(fast),
 
 	// Bundled files
 	defineConfig({

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ export const pvtnbr = (
 		eslint,
 		serviceWorkers,
 		eslintComments,
-		...imports(options?.mode),
+		...imports(options?.fast),
 		...unicorn(options),
 		...stylistic,
 		typescript(tsconfig),

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ export const pvtnbr = (
 		eslint,
 		serviceWorkers,
 		eslintComments,
-		...imports,
+		...imports(options?.mode),
 		...unicorn(options),
 		...stylistic,
 		typescript(tsconfig),

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,6 @@ import type { Options as UnicornOptions } from './configs/unicorn.ts';
 
 export type Options = {
 	cwd?: string;
-	mode?: 'full' | 'fast';
+	fast?: boolean;
 	node?: boolean | Linter.Config['files'];
 } & UnicornOptions;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,5 +3,6 @@ import type { Options as UnicornOptions } from './configs/unicorn.ts';
 
 export type Options = {
 	cwd?: string;
+	mode?: 'full' | 'fast';
 	node?: boolean | Linter.Config['files'];
 } & UnicornOptions;

--- a/tests/cli/index.ts
+++ b/tests/cli/index.ts
@@ -12,12 +12,50 @@ import { createGit } from '../utils/create-git.ts';
 // Normalize path separators for platform (forward slash on Unix, backslash on Windows)
 const slash = (filePath: string) => filePath.replaceAll('/', path.sep);
 
+const threeModuleCycle = {
+	'package.json': JSON.stringify({ type: 'module' }),
+	'a.js': "import { b } from './b.js';\n\nexport const a = b;\n",
+	'b.js': "import { c } from './c.js';\n\nexport const b = c;\n",
+	'c.js': "import { a } from './a.js';\n\nexport const c = a;\n",
+};
+
 describe('cli', () => {
 	test('implicitly lints cwd', async () => {
 		const cwd = fileURLToPath(new URL('fixtures/', import.meta.url));
 		const results = await lintroll([], cwd);
 
 		expect(results.output).toContain('fail.js');
+	});
+
+	describe('fast mode', () => {
+		test('limits cycle detection depth', async () => {
+			await using fixture = await createFixture(threeModuleCycle);
+
+			const full = await lintroll([], fixture.path);
+			const fast = await lintroll(['--fast'], fixture.path);
+
+			expect(full.output).toContain('import-x/no-cycle');
+			expect(fast.output).not.toContain('import-x/no-cycle');
+		});
+
+		test('uses LINTROLL_MODE=fast', async () => {
+			await using fixture = await createFixture(threeModuleCycle);
+
+			const result = await lintroll([], fixture.path, { LINTROLL_MODE: 'fast' });
+
+			expect(result.output).not.toContain('import-x/no-cycle');
+		});
+
+		test('rejects explicit config files', async () => {
+			await using fixture = await createFixture({
+				'package.json': JSON.stringify({ type: 'module' }),
+				'eslint.config.js': 'export default []\n',
+			});
+
+			const result = await lintroll(['--fast'], fixture.path);
+
+			expect(result.output).toContain('Fast mode is unavailable with eslint.config.js');
+		});
 	});
 
 	describe('--git flag', () => {

--- a/tests/cli/index.ts
+++ b/tests/cli/index.ts
@@ -13,7 +13,13 @@ import { createGit } from '../utils/create-git.ts';
 const slash = (filePath: string) => filePath.replaceAll('/', path.sep);
 
 const threeModuleCycle = {
-	'package.json': JSON.stringify({ type: 'module' }),
+	'package.json': `${JSON.stringify({
+		name: 'cycle-fixture',
+		version: '1.0.0',
+		license: 'MIT',
+		private: true,
+		type: 'module',
+	}, null, '\t')}\n`,
 	'a.js': "import { b } from './b.js';\n\nexport const a = b;\n",
 	'b.js': "import { c } from './c.js';\n\nexport const b = c;\n",
 	'c.js': "import { a } from './a.js';\n\nexport const c = a;\n",

--- a/tests/imports/index.ts
+++ b/tests/imports/index.ts
@@ -156,7 +156,13 @@ describe('imports', () => {
 
 	test('fast mode detects direct cycles', async () => {
 		await using fixture = await createFixture({
-			'package.json': JSON.stringify({ type: 'module' }),
+			'package.json': `${JSON.stringify({
+				name: 'direct-cycle-fixture',
+				version: '1.0.0',
+				license: 'MIT',
+				private: true,
+				type: 'module',
+			}, null, '\t')}\n`,
 			'a.js': "import { b } from './b.js';\n\nexport const a = b;\n",
 			'b.js': "import { a } from './a.js';\n\nexport const b = a;\n",
 		});
@@ -181,7 +187,13 @@ describe('imports', () => {
 
 	test('fast mode does not reuse full mode cache entries', async () => {
 		await using fixture = await createFixture({
-			'package.json': JSON.stringify({ type: 'module' }),
+			'package.json': `${JSON.stringify({
+				name: 'cached-cycle-fixture',
+				version: '1.0.0',
+				license: 'MIT',
+				private: true,
+				type: 'module',
+			}, null, '\t')}\n`,
 			'a.js': "import { b } from './b.js';\n\nexport const a = b;\n",
 			'b.js': "import { c } from './c.js';\n\nexport const b = c;\n",
 			'c.js': "import { a } from './a.js';\n\nexport const c = a;\n",

--- a/tests/imports/index.ts
+++ b/tests/imports/index.ts
@@ -2,12 +2,17 @@ import {
 	describe, test, expect, onTestFail,
 } from 'manten';
 import { ESLint } from 'eslint';
+import { createFixture } from 'fs-fixture';
 import { pvtnbr } from '#pvtnbr';
 import { eslint } from '../utils/eslint.ts';
 
 const orderMessages = (
 	messages: { ruleId: string | null }[],
 ) => messages.filter(message => message.ruleId === 'import-x/order');
+
+const hasCycle = (
+	messages: { ruleId: string | null }[],
+) => messages.some(message => message.ruleId === 'import-x/no-cycle');
 
 /**
  * ESLint instance with internal-regex to classify `@internal/*` as internal imports.
@@ -147,5 +152,76 @@ describe('imports', () => {
 
 			expect(orderMessages(result.messages).length).toBeGreaterThan(0);
 		});
+	});
+
+	test('fast mode detects direct cycles', async () => {
+		await using fixture = await createFixture({
+			'package.json': JSON.stringify({ type: 'module' }),
+			'a.js': "import { b } from './b.js';\n\nexport const a = b;\n",
+			'b.js': "import { a } from './a.js';\n\nexport const b = a;\n",
+		});
+
+		const fixtureEslint = new ESLint({
+			cwd: fixture.path,
+			baseConfig: pvtnbr({ mode: 'fast' }),
+			overrideConfigFile: true,
+		});
+		const results = await fixtureEslint.lintFiles([
+			fixture.getPath('a.js'),
+			fixture.getPath('b.js'),
+		]);
+		const messages = results.flatMap(result => result.messages);
+
+		onTestFail(() => {
+			console.log(messages);
+		});
+
+		expect(hasCycle(messages)).toBe(true);
+	});
+
+	test('fast mode does not reuse full mode cache entries', async () => {
+		await using fixture = await createFixture({
+			'package.json': JSON.stringify({ type: 'module' }),
+			'a.js': "import { b } from './b.js';\n\nexport const a = b;\n",
+			'b.js': "import { c } from './c.js';\n\nexport const b = c;\n",
+			'c.js': "import { a } from './a.js';\n\nexport const c = a;\n",
+		});
+
+		const files = [
+			fixture.getPath('a.js'),
+			fixture.getPath('b.js'),
+			fixture.getPath('c.js'),
+		];
+		const cacheLocation = fixture.getPath('.eslintcache');
+		const full = new ESLint({
+			cache: true,
+			cacheLocation,
+			cwd: fixture.path,
+			baseConfig: pvtnbr(),
+			overrideConfigFile: true,
+		});
+		const fullResults = await full.lintFiles(files);
+		const fullMessages = fullResults.flatMap(result => result.messages);
+
+		expect(hasCycle(fullMessages)).toBe(true);
+
+		const fast = new ESLint({
+			cache: true,
+			cacheLocation,
+			cwd: fixture.path,
+			baseConfig: pvtnbr({ mode: 'fast' }),
+			overrideConfigFile: true,
+		});
+		const fastResults = await fast.lintFiles(files);
+		const fastMessages = fastResults.flatMap(result => result.messages);
+
+		onTestFail(() => {
+			console.log({
+				fullMessages,
+				fastMessages,
+			});
+		});
+
+		expect(hasCycle(fastMessages)).toBe(false);
 	});
 });

--- a/tests/imports/index.ts
+++ b/tests/imports/index.ts
@@ -169,7 +169,7 @@ describe('imports', () => {
 
 		const fixtureEslint = new ESLint({
 			cwd: fixture.path,
-			baseConfig: pvtnbr({ mode: 'fast' }),
+			baseConfig: pvtnbr({ fast: true }),
 			overrideConfigFile: true,
 		});
 		const results = await fixtureEslint.lintFiles([
@@ -221,7 +221,7 @@ describe('imports', () => {
 			cache: true,
 			cacheLocation,
 			cwd: fixture.path,
-			baseConfig: pvtnbr({ mode: 'fast' }),
+			baseConfig: pvtnbr({ fast: true }),
 			overrideConfigFile: true,
 		});
 		const fastResults = await fast.lintFiles(files);

--- a/tests/utils/eslint.ts
+++ b/tests/utils/eslint.ts
@@ -17,6 +17,7 @@ export const eslint = createEslint();
 export const lintroll = (
 	args: string[],
 	cwd: string,
+	env?: NodeJS.ProcessEnv,
 ) => spawn(
 	process.execPath,
 	[
@@ -25,5 +26,6 @@ export const lintroll = (
 	],
 	{
 		cwd,
+		env,
 	},
 ).catch(error => error as SubprocessError);


### PR DESCRIPTION
## Problem

Unbounded import-cycle traversal dominates lintroll's rule time on the benchmark workload. Consumers sometimes need a faster feedback loop while retaining direct-cycle protection.

## Changes

- Add `pvtnbr({ mode: 'fast' })`, CLI `--fast`, and CLI-only `LINTROLL_MODE=fast`.
- Fast mode limits `import-x/no-cycle` to direct cycles; full mode remains unchanged.
- Reject fast mode when a project supplies its own `eslint.config.*`, where callers can use `pvtnbr({ mode: 'fast' })` directly.
- Add generated-config benchmarks and tests for fast-mode cycle coverage and cache separation.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #128
2. `develop`
3. **#129** 👈 current
<!-- stack:links:end -->