### PR TITLE
ci: require frozen lockfile

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           restore-keys: ${{ runner.os }}-pnpm-
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Type check
         run: pnpm type-check

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 			"default": "./dist/cli/index.mjs"
 		}
 	},
-	"packageManager": "pnpm@10.27.0",
+	"packageManager": "pnpm@10.34.5",
 	"scripts": {
 		"bench": "node --expose-gc bench/lint.ts",
 		"bench:rules": "node bench/rules.ts",


### PR DESCRIPTION
## Problem

CI can silently ignore a malformed lockfile and resolve newer dependency versions than development uses. That makes builds non-reproducible and can introduce unreviewed dependency changes.

## Changes

Require `pnpm install --frozen-lockfile` in the test workflow so CI fails on lockfile drift instead of resolving a different dependency graph.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. `develop`
2. **#130** 👈 current
<!-- stack:links:end -->